### PR TITLE
Decode bencoded lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,2 @@
+### Bit-torrent RUST implementation
+BitTorrent is a peer-to-peer file sharing protocol used for distributing large amounts of data. In this challenge, you'll build a BitTorrent client that's capable of downloading a publicly available file using the BitTorrent protocol.

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,3 +1,3 @@
 git add .
-git commit -S -m "devop: avoid deep ifs"
+git commit -S -m "devop: decode bencoded lists"
 git push origin develop

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,18 +5,44 @@ use std::env;
 // use serde_bencode
 
 #[allow(dead_code)]
-fn decode_bencoded_value(encoded_value: &str) -> serde_json::Value {
+fn decode_bencoded_value(encoded_value: &str) -> (serde_json::Value, &str) {
     // If encoded_value starts with a digit, it's a number
-    if let Some(n) = encoded_value
-        .strip_prefix("i")
-        .and_then(|rest| rest.split_once("e"))
-        .and_then(|(digits, _)| digits.parse::<i64>().ok()) {
-            return n.into();
-        } else if let Some((len, rest)) = encoded_value.split_once(":") {
-            if let Ok(len) = len.parse::<usize>() {
-                return serde_json::Value::String(rest[..len].to_string());
-            }     
+    match encoded_value.chars().next() {
+        Some('i') => {
+            // i52e
+            if let Some((n, rest)) = encoded_value.split_at(1).1.split_once('e').and_then(|(digits, rest)| {
+                let n = digits.parse::<i64>().ok()?;
+
+                Some((n, rest))
+
+            }) {
+                return (n.into(), rest);
+            }
         }
+        Some('l') => {
+            // l5:helloi52ee
+            let mut values = Vec::new();
+            let mut rest = encoded_value.split_at(1).1;
+
+            while !rest.is_empty() && !rest.starts_with('e')  {
+                let (v, remainder) = decode_bencoded_value(rest);
+                values.push(v);
+
+                rest = remainder;
+            }
+
+            return (values.into(), &rest[1..]);
+        }
+        Some('0'..='9') => {
+            if let Some((len, rest)) = encoded_value.split_once(':') {
+                if let Ok(len) = len.parse::<usize>() {
+                    return (rest[..len].to_string().into(), &rest[len..]);
+                }
+            }
+        }
+        _ => {}
+    }
+
     panic!("Unhandled value: {}", encoded_value)
 }
 
@@ -32,7 +58,7 @@ fn main() {
         // Uncomment this block to pass the first stage
         let encoded_value = &args[2];
         let decoded_value = decode_bencoded_value(encoded_value);
-        println!("{}", decoded_value.to_string());
+        println!("{}", decoded_value.0.to_string());
     } else {
         println!("unknown command: {}", args[1])
     }


### PR DESCRIPTION
Extend the decode command to support bencoded lists.

Lists are encoded as l<bencoded_elements>e.

For example, ["hello", 52] would be encoded as l5:helloi52ee. Note that there are no separators between the elements.

Here’s how the tester will execute your program:

$ ./your_bittorrent.sh decode l5:helloi52ee
[“hello”,52]
If you'd prefer to use a library crate for this stage, [serde-bencode](https://github.com/toby/serde-bencode/) is available for you to use.